### PR TITLE
`docs/.vuepress/sidebar.js`: Add `Standing Orders` menu entry for all the versions.

### DIFF
--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -42,6 +42,10 @@ module.exports = [
     //                     path: '/v3.1.4/resources-and-data-models/aisp/direct-debits',
     //                 },
     //                 {
+    //                     title: 'Standing Orders',
+    //                     path: '/v3.1.4/resources-and-data-models/aisp/standing-orders',
+    //                 },
+    //                 {
     //                     title: 'Products',
     //                     path: '/v3.1.4/resources-and-data-models/aisp/Products',
     //                     collapsable: collapsable,
@@ -244,6 +248,10 @@ module.exports = [
                         path: '/v3.1.3/resources-and-data-models/aisp/direct-debits',
                     },
                     {
+                        title: 'Standing Orders',
+                        path: '/v3.1.3/resources-and-data-models/aisp/standing-orders',
+                    },
+                    {
                         title: 'Products',
                         path: '/v3.1.3/resources-and-data-models/aisp/Products',
                         collapsable: collapsable,
@@ -444,6 +452,10 @@ module.exports = [
                     {
                         title: 'Direct Debits',
                         path: '/v3.1.2/resources-and-data-models/aisp/direct-debits',
+                    },
+                    {
+                        title: 'Standing Orders',
+                        path: '/v3.1.2/resources-and-data-models/aisp/standing-orders',
                     },
                     {
                         title: 'Products',

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -37,8 +37,3 @@ html, body, #app, .theme-container {
   // Make this elements fill the entire width.
   max-width: 100%;
 }
-
-// TODO(mbana): Remove HACK.
-#app > div.theme-container > aside > ul > li:nth-child(1) {
-  display: none;
-}


### PR DESCRIPTION
`docs/.vuepress/sidebar.js`: Add `Standing Orders` menu entry for all the versions.

`Standing Orders` appears above `Products` in the below:

<img width="1792" alt="Screenshot 2019-11-27 at 16 53 36" src="https://user-images.githubusercontent.com/22658/69743557-87a70e80-1136-11ea-97aa-79db20f028ed.png">
